### PR TITLE
Use Conan to manage third parties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-        with:
-          submodules: true
 
       - name: Install tools
         run: sudo apt-get install ninja-build python3-pip libgl-dev && pip install conan
@@ -19,6 +17,12 @@ jobs:
         run: |
           mkdir build
           cd build
+
+      - name: Cache Conan folder
+        id: cache-conan
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.conan
 
       - name: Install 3rd parties
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/.conan
+          key: '{{ runner.os }}-conan'
 
       - name: Install 3rd parties
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,9 @@ jobs:
           mkdir build
           cd build
 
-      - name: Setup Conan profile
-        run: |
-          conan profile new release
-          conan profile update settings.build_type=Release release
-          conan profile update settings.compiler.libcxx=libstdc++11 release
-          conan profile update settings.cppstd=20 release
-
       - name: Install 3rd parties
         working-directory: build
-        run: conan install .. --profile release
+        run: conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=20 -s build_type=Release --build=missing
         
       - name: Configure
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install 3rd parties
         working-directory: build
-        run: conan install .. -p release
+        run: conan install .. --profile release
         
       - name: Configure
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,23 @@ jobs:
           submodules: true
 
       - name: Install tools
-        run: sudo apt-get install ninja-build python3-pip && pip install conan
+        run: sudo apt-get install ninja-build python3-pip libgl-dev && pip install conan
 
       - name: Create directories
         run: |
           mkdir build
           cd build
 
+      - name: Setup Conan profile
+        run: |
+          conan profile new release
+          conan profile update settings.build_type=Release release
+          conan profile update settings.compiler.libcxx=libstdc++11 release
+          conan profile update settings.cppstd=20 release
+
       - name: Install 3rd parties
         working-directory: build
-        run: conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=20 -s build_type=Release --build=missing
+        run: conan install .. -p release
         
       - name: Configure
         working-directory: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,55 +12,21 @@ jobs:
         with:
           submodules: true
 
-      - name: Cache Qt
-        id: cache-qt
-        uses: actions/cache@v2.1.4
-        with:
-          path: /opt/Qt
-          key: ${{ runner.os }}-qt-compiled
+      - name: Install tools
+        run: sudo apt-get install ninja-build python3-pip && pip install conan
 
-      - name: Install Qt5
-        uses: jurplel/install-qt-action@v2
-        with:
-          version: '5.14.1'
-          dir: '/opt/Qt'
-          install-deps: 'true'
-          modules: 'qtcharts qtwebengine'
-          cached: ${{ steps.cache-qt.outputs.cache-hit }}
-
-      - name: Cache Protobuf
-        id: cache-protobuf
-        uses: actions/cache@v2.1.4
-        with:
-          path: /opt/protobuf
-          key: ${{ runner.os }}-protobuf-compiled
-
-      - name: Download and build Protobuf
-        if: steps.cache-protobuf.outputs.cache-hit != 'true'
-        working-directory: /opt/
-        run: |
-          git clone -b 3.11.x https://github.com/protocolbuffers/protobuf protobuf
-          cd protobuf
-          git submodule update --init --recursive
-          ./autogen.sh
-          ./configure
-          make -j`nproc`
-          make -j`nproc` check
-
-      - name: Install Protobuf
-        working-directory: /opt/protobuf
-        run: |
-          sudo make install
-          sudo ldconfig
-
-      - name: Install Ninja
-        run: sudo apt-get install ninja-build
-
-      - name: Configure
+      - name: Create directories
         run: |
           mkdir build
           cd build
-          cmake .. -GNinja
+
+      - name: Install 3rd parties
+        working-directory: build
+        run: conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=20 -s build_type=Release --build=missing
+        
+      - name: Configure
+        working-directory: build
+        run: cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release
         
       - name: Build
         working-directory: build
@@ -68,4 +34,4 @@ jobs:
         
       - name: Test
         working-directory: build
-        run: ctest -E ".*tcp.*"
+        run: ctest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "libs/googletest"]
-	path = libs/googletest
-	url = git@github.com:google/googletest.git
-[submodule "libs/nlohmann-json"]
-	path = libs/nlohmann-json
-	url = git@github.com:nlohmann/json.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,25 @@
 cmake_minimum_required(VERSION 3.17)
 project(cute)
 
-add_subdirectory(libs)
+include("${CMAKE_BINARY_DIR}/conan_paths.cmake")
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup(TARGETS)
 
 ## Libraries
-# Qt5
-set(CMAKE_PREFIX_PATH /opt/Qt/5.14.1/gcc_64/)
-find_package(Qt5 COMPONENTS Core Widgets Network Charts REQUIRED)
-
-# Protobuf, for messages
-find_package(Protobuf REQUIRED)
-
-# Google Tests
-include(GoogleTest)
 enable_testing()
+include(conan_qt_executables_variables)
+include(Qt5CoreMacros)
+include(Qt5WidgetsMacros)
+
+find_package(GTest)
+
 
 # Uh
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 add_subdirectory(src)
 
-if (UNIX)
-    add_custom_target(clean_gcda ALL COMMAND find -name "*.gcda" -delete COMMENT "Cleaning GCDA files")
-    add_custom_target(coverage COMMAND gcovr -r ../src ./ -e ".*gtest.*" -e ".*/tests/.*" --html-details -o coverage.html)
-endif()
+# if (UNIX)
+#     add_custom_target(clean_gcda ALL COMMAND find -name "*.gcda" -delete COMMENT "Cleaning GCDA files")
+#     add_custom_target(coverage COMMAND r -r ../src ./ -e ".*gtest.*" -e ".*/tests/.*" --html-details -o coverage.html)
+# endif()

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 ## Contents
 
-- [Goals](#Goals)
-- [Structure](#Structure)
-- [Depends](#Depends)
-- [Building](#Building)
-- [Testing](#Testing)
+- [CuteStation](#cutestation)
+  - [Contents](#contents)
+  - [Goals](#goals)
+  - [Structure](#structure)
+  - [Depends](#depends)
+  - [Building](#building)
+  - [Testing](#testing)
 
 ## Goals
 
@@ -54,12 +56,9 @@ a Google Test-driven unit test executable named `<target>.test` (e.g.:
 
 ## Depends
 
-- [Protobuf 3.11](https://github.com/protocolbuffers/protobuf/)
-- [nlohmann::json](https://github.com/nlohmann/json)
-- Qt 5.14.1
+- Conan
 - CMake 3.17 (for [CMP0100](https://cmake.org/cmake/help/v3.17/policy/CMP0100.html))
 - Ninja (recommended)
-- gcovr (recommended)
 
 CuteStation uses C++20 features and syntax; a modern compiler is required. The
 officially supported compiler is GCC 9.3.0.
@@ -71,19 +70,16 @@ To clone:
 ```bash
 git clone https://github.com/ngc7293/cutestation
 cd cutestation
-git submodule update --init --recursive # For Google Test
 ```
 
 To build
 
 ```bash
 mkdir build; cd build;
+conan install .. -s compiler.libcxx=libstdc++11 -s cppstd=20 -s build_type=Debug --build=missing
 cmake .. -G Ninja
 ninja
 ```
-
-Note that the current CMakeLists assumes Qt to be installed in
-`/opt/Qt/5.14.1/`, you might need to update it to match your install path.
 
 ## Testing
 
@@ -91,9 +87,11 @@ Most modules have unit tests. These are built with Google Test into one
 executable per module, using the syntax `<module>.test`. They can be found in
 the `build/bin` directory.
 
+**Coverage is currently disabled. We'll be back soon.**
+
 After running tests, you can generate the coverage report with `ninja coverage`.
 Detailed coverage information will be written to `build/coverage.html`.
 
 **Note**: Linux will purposefully keep TCP sockets alive for a certain time
 after they are closed. This will cause the TCP Server tests to fail if called
-repeatedly. These failures can be ignored.
+repeatedly. These failures can be ignored (the tests are DISABLED in gtest)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,17 @@
+[requires]
+qt/5.15.2
+protobuf/3.17.1
+nlohmann_json/3.9.1
+gtest/1.10.0
+
+[options]
+qt:shared=True
+qt:qtcharts=True
+qt:with_mysql=False
+qt:with_pq=False
+qt:with_sqlite3=False
+qt:with_odbc=False
+ 
+[generators]
+cmake
+cmake_paths

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,4 +1,0 @@
-add_subdirectory(googletest)
-
-set(JSON_BuildTests OFF CACHE INTERNAL "")
-add_subdirectory(nlohmann-json)

--- a/src/cute/CMakeLists.txt
+++ b/src/cute/CMakeLists.txt
@@ -23,9 +23,8 @@ SET(UI
     ui/window.ui
 )
 
-add_executable(cute ${SOURCES} ${HEADERS} ${UI})
+add_executable(cute ${SOURCES} ${HEADERS} ${QT_SOURCES} ${UI_SOURCES})
 set_property(TARGET cute PROPERTY CXX_STANDARD 20)
 target_include_directories(cute PRIVATE src/)
-target_compile_options(cute PRIVATE -Wall -Wpedantic -Werror --coverage)
-target_link_options(cute PRIVATE --coverage)
-target_link_libraries(cute PUBLIC cute.widgets cute.data cute.io cute.log cute.util nlohmann_json::nlohmann_json Qt5::Core Qt5::Network Qt5::Widgets)
+target_compile_options(cute PUBLIC -fPIC PRIVATE -Wall -Wpedantic -Werror)
+target_link_libraries(cute PUBLIC cute.widgets cute.data cute.io cute.log cute.util CONAN_PKG::nlohmann_json CONAN_PKG::qt)

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -18,18 +18,15 @@ set(HEADERS
 add_library(cute.data STATIC ${SOURCES} ${HEADERS})
 set_property(TARGET cute.data PROPERTY CXX_STANDARD 20)
 target_include_directories(cute.data PUBLIC inc/ PRIVATE src/)
-target_compile_options(cute.data PRIVATE -Wall -Wpedantic -Werror --coverage)
-target_link_libraries(cute.data PUBLIC cute.log cute.proto topic cute.util nlohmann_json::nlohmann_json Qt5::Core Qt5::Widgets Qt5::Charts)
+target_compile_options(cute.data PUBLIC -fPIC PRIVATE -Wall -Wpedantic -Werror)
+target_link_libraries(cute.data PUBLIC cute.log cute.proto topic cute.util CONAN_PKG::nlohmann_json CONAN_PKG::qt)
 
-## Tests
-set( TESTS
-tests/main.cc
-tests/test_time_series.cc
+# Tests
+set(TESTS
+    tests/main.cc
+    tests/test_time_series.cc
 )
 
 add_executable(cute.data.test ${TESTS})
+target_link_libraries(cute.data.test PUBLIC cute.data topic CONAN_PKG::gtest)
 gtest_discover_tests(cute.data.test)
-
-target_compile_options(cute.data.test PRIVATE --coverage)
-target_link_options(cute.data.test PRIVATE --coverage)
-target_link_libraries(cute.data.test PUBLIC cute.data topic gcov gtest)

--- a/src/io/CMakeLists.txt
+++ b/src/io/CMakeLists.txt
@@ -17,11 +17,11 @@ set(SOURCES
 add_library(cute.io STATIC ${SOURCES} ${HEADERS})
 set_property(TARGET cute.io PROPERTY CXX_STANDARD 20)
 target_include_directories(cute.io PUBLIC inc/ PRIVATE src/)
-target_compile_options(cute.io PRIVATE -Wall -Wpedantic -Werror --coverage)
+target_compile_options(cute.io PRIVATE -Wall -Wpedantic -Werror )
 target_link_libraries(cute.io PUBLIC cute.log cute.util topic cute.proto net)
 
 # Tests
-set( TESTS
+set(TESTS
     tests/main.cc
     tests/test_client.cc
     tests/test_dispatcher.cc
@@ -29,8 +29,5 @@ set( TESTS
 )
 
 add_executable(cute.io.test ${TESTS})
+target_link_libraries(cute.io.test PUBLIC cute.io CONAN_PKG::gtest)
 gtest_discover_tests(cute.io.test)
-
-target_compile_options(cute.io.test PUBLIC --coverage)
-target_link_options(cute.io.test PUBLIC --coverage)
-target_link_libraries(cute.io.test PUBLIC cute.io gcov gtest)

--- a/src/io/tests/test_socket_dispatcher.cc
+++ b/src/io/tests/test_socket_dispatcher.cc
@@ -21,7 +21,7 @@ TEST(SocketDispatcher, creates_a_valid_unix_socket)
     dispatcher.close();
 }
 
-TEST(SocketDispatcher, creates_a_valid_tcp_socket)
+TEST(SocketDispatcher, DISABLED_creates_a_valid_tcp_socket)
 {
     cute::io::SocketDispatcher dispatcher;
 

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -16,11 +16,11 @@ set(HEADERS
 add_library(net STATIC ${SOURCES} ${HEADERS})
 set_property(TARGET net PROPERTY CXX_STANDARD 20)
 target_include_directories(net PUBLIC inc/ PRIVATE src/)
-target_compile_options(net PRIVATE -Wall -Wpedantic -Werror --coverage)
+target_compile_options(net PRIVATE -Wall -Wpedantic -Werror)
 target_link_libraries(net PUBLIC cute.log)
 
-## Tests
-set( TESTS
+# Tests
+set(TESTS
     tests/main.cc
     tests/test_stream.cc
     tests/test_tcp.cc
@@ -28,8 +28,5 @@ set( TESTS
 )
 
 add_executable(net.test ${TESTS})
+target_link_libraries(net.test PUBLIC net CONAN_PKG::gtest)
 gtest_discover_tests(net.test)
-
-target_compile_options(net.test PUBLIC --coverage)
-target_link_options(net.test PUBLIC --coverage)
-target_link_libraries(net.test PUBLIC net gcov gtest)

--- a/src/net/tests/test_tcp.cc
+++ b/src/net/tests/test_tcp.cc
@@ -6,7 +6,7 @@
 #include <net/server.hh>
 #include <net/socket.hh>
 
-TEST(tcp_server, listen_succeeds)
+TEST(tcp_server, DISABLED_listen_succeeds)
 {
     net::server server;
 
@@ -20,7 +20,7 @@ TEST(tcp_server, listen_succeeds)
     EXPECT_TRUE(ret.get());
 }
 
-TEST(tcp_server, sockets_can_connect)
+TEST(tcp_server, DISABLED_sockets_can_connect)
 {
     net::server server;
     net::socket socket;
@@ -36,7 +36,7 @@ TEST(tcp_server, sockets_can_connect)
     a.wait();
 }
 
-TEST(tcp_server, server_creates_new_socket)
+TEST(tcp_server, DISABLED_server_creates_new_socket)
 {
     net::server server;
     net::socket socket;
@@ -69,7 +69,7 @@ TEST(tcp_server, server_creates_new_socket)
     a.wait();
 }
 
-TEST(tcp_socket, socket_connect_fails_with_no_server)
+TEST(tcp_socket, DISABLED_socket_connect_fails_with_no_server)
 {
     net::socket socket;
 

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.17)
 
-SET( HEADERS
+SET(HEADERS
     inc/proto/packet.hh
     inc/proto/delimited_protobuf_stream.hh
 )
 
-set( SOURCES
+set(SOURCES
     src/packet.cc
 )
 
-SET( PROTO
+SET(PROTO
     packet.proto
 )
 
@@ -21,18 +21,15 @@ set_property(SOURCE ${PROTO_SOURCES} PROPERTY SKIP_AUTOGEN ON)
 add_library(cute.proto STATIC ${HEADERS} ${SOURCES} ${PROTO_SOURCES} ${PROTO_HEADERS})
 target_compile_features(cute.proto PUBLIC cxx_std_20)
 target_include_directories(cute.proto PUBLIC inc/ ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cute.proto PUBLIC protobuf::libprotobuf)
+target_link_libraries(cute.proto PUBLIC CONAN_PKG::protobuf)
 
-## Tests
-set( TESTS
+# Tests
+set(TESTS
     tests/main.cc
     tests/test_packet.cc
     tests/test_stream.cc
 )
 
 add_executable(cute.proto.test ${TESTS})
+target_link_libraries(cute.proto.test PUBLIC cute.proto CONAN_PKG::gtest)
 gtest_discover_tests(cute.proto.test)
-
-target_compile_options(cute.proto.test PUBLIC --coverage)
-target_link_options(cute.proto.test PUBLIC --coverage)
-target_link_libraries(cute.proto.test PUBLIC cute.proto gcov gtest)

--- a/src/topic/CMakeLists.txt
+++ b/src/topic/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required(VERSION 3.16.0)
-project(cute)
+cmake_minimum_required(VERSION 3.17.0)
 
-## FILES
-SET( HEADERS
+SET(HEADERS
     inc/topic/callback.hh
     inc/topic/publisher.hh
     inc/topic/subscribe_info.hh
@@ -13,7 +11,7 @@ SET( HEADERS
     src/topic.hh
 )
 
-set( SOURCES
+set(SOURCES
     src/publisher.cc
     src/subscriber.cc
     src/local_topic_manager.cc
@@ -22,22 +20,19 @@ set( SOURCES
     src/topic.cc
 )
 
-## Target
+# Target
 add_library(topic STATIC ${SOURCES} ${HEADERS})
 
 target_compile_features(topic PUBLIC cxx_std_17)
 target_include_directories(topic PUBLIC inc PRIVATE src)
 target_compile_options(topic PRIVATE -Wall -Werror -Wpedantic)
 
-## Tests
-set( TESTS
+# Tests
+set(TESTS
     tests/main.cc
     tests/test_pubsub.cc
 )
 
 add_executable(topic.test ${TESTS})
+target_link_libraries(topic.test PUBLIC topic CONAN_PKG::gtest)
 gtest_discover_tests(topic.test)
-
-target_compile_options(topic.test PUBLIC )
-target_link_options(topic.test PUBLIC )
-target_link_libraries(topic.test PUBLIC topic gcov gtest)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -12,22 +12,18 @@ set(SOURCES
 )
 
 add_library(cute.util STATIC ${SOURCES} ${HEADERS})
-set_property(TARGET cute.util PROPERTY CXX_STANDARD 20)
+target_compile_features(cute.util PUBLIC cxx_std_20)
 target_include_directories(cute.util PUBLIC inc/ PRIVATE src/)
-target_compile_options(cute.util PRIVATE -Wall -Wpedantic -Werror --coverage)
-target_link_libraries(cute.util PUBLIC cute.log nlohmann_json::nlohmann_json Qt5::Core)
+target_compile_options(cute.util PUBLIC -fPIC PRIVATE -Wall -Wpedantic -Werror)
+target_link_libraries(cute.util PUBLIC cute.log CONAN_PKG::nlohmann_json CONAN_PKG::qt)
 
-## Tests
-set( TESTS
+# Tests
+set(TESTS
     tests/main.cc
     tests/test_json.cc
     tests/test_switch.cc
 )
 
 add_executable(cute.util.test ${TESTS})
+target_link_libraries(cute.util.test PUBLIC cute.util CONAN_PKG::gtest)
 gtest_discover_tests(cute.util.test)
-
-set_property(TARGET cute.util.test PROPERTY CXX_STANDARD 20)
-target_compile_options(cute.util.test PUBLIC --coverage)
-target_link_options(cute.util.test PUBLIC --coverage)
-target_link_libraries(cute.util.test PUBLIC cute.util gcov gtest)

--- a/src/widgets/CMakeLists.txt
+++ b/src/widgets/CMakeLists.txt
@@ -27,8 +27,8 @@ set(HEADERS
     inc/widgets/widget.hh
 )
 
-add_library(cute.widgets STATIC ${SOURCES} ${HEADERS})
+add_library(cute.widgets STATIC ${SOURCES} ${HEADERS} ${QT_SOURCES})
 set_property(TARGET cute.widgets PROPERTY CXX_STANDARD 20)
 target_include_directories(cute.widgets PUBLIC inc/ PRIVATE src/)
-target_compile_options(cute.widgets PRIVATE -Wall -Wpedantic -Werror)
-target_link_libraries(cute.widgets PUBLIC cute.data cute.log cute.util nlohmann_json::nlohmann_json Qt5::Core Qt5::Widgets Qt5::Charts)
+target_compile_options(cute.widgets PUBLIC -fPIC PRIVATE -Wall -Wpedantic -Werror)
+target_link_libraries(cute.widgets PUBLIC cute.data cute.log cute.util CONAN_PKG::nlohmann_json CONAN_PKG::qt)

--- a/src/widgets/src/widget_factory.cc
+++ b/src/widgets/src/widget_factory.cc
@@ -22,7 +22,7 @@ ChartWidget* WidgetFactory::build(const json& config, QWidget* parent)
     ChartWidget* widget = nullptr;
 
     std::string name;
-    unsigned length, refresh_rate;;
+    unsigned length, refresh_rate;
     std::vector<int> range;
 
     std::shared_ptr<data::TimeSeries<double>> series = data::SeriesFactory::build<data::TimeSeries<double>>(config);
@@ -43,6 +43,7 @@ ChartWidget* WidgetFactory::build(const json& config, QWidget* parent)
     widget->set_series(series);
     widget->set_range(std::min(range[0], range[1]), std::max(range[0], range[1]));
     widget->set_length(length);
+    widget->start(refresh_rate);
     return widget;
 }
 

--- a/tools/python/test.py
+++ b/tools/python/test.py
@@ -27,8 +27,7 @@ def main(args):
 
     packet = Packet()
     packet.handshake.name = "python_testing"
-    # packet.handshake.commands.append(Handshake.Command(name="anirniq.remote_control.engine.sequence.start", type=Handshake.Command.Type.BOOL))
-    print(packet.IsInitialized())
+    packet.handshake.commands.append(Handshake.Command(name="anirniq.remote_control.engine.sequence.stop", type=Handshake.Command.Type.BOOL))
     print(json_format.MessageToJson(packet))
 
     sock.send(packet.ByteSize().to_bytes(8, byteorder='little'))


### PR DESCRIPTION
Removes submodules and dependency on manually installed third parties (protobuf, Qt)